### PR TITLE
Fixed too few parameters in automatic login

### DIFF
--- a/Controller/Raas/Automatic/Login.php
+++ b/Controller/Raas/Automatic/Login.php
@@ -75,7 +75,7 @@ class Login extends AbstractLogin
      * @param CookieMetadataFactory $cookieMetadataFactory
      * @param LoginHelper $loginHelper
      * @param Extend $extendModel
-	 * @param JsonFactory $jsonFactory
+     * @param JsonFactory $jsonFactory
      */
     public function __construct(
         Context $context,
@@ -102,9 +102,11 @@ class Login extends AbstractLogin
         CookieManagerInterface $cookieManager,
         GigyaMageHelper $gigyaMageHelper,
         CookieMetadataFactory $cookieMetadataFactory,
-        LoginHelper $loginHelper,
         Extend $extendModel,
-		JsonFactory $jsonFactory
+        JsonFactory $jsonFactory,
+        Logger $logger,
+        JsonSerializer $jsonSerializer,
+        LoginHelper $loginHelper
     )
     {
         parent::__construct(
@@ -133,7 +135,9 @@ class Login extends AbstractLogin
             $gigyaMageHelper,
             $cookieMetadataFactory,
             $extendModel,
-			$jsonFactory
+            $jsonFactory,
+            $logger,
+            $jsonSerializer
         );
 
         $this->loginHelper = $loginHelper;


### PR DESCRIPTION
Fixes

```
report.CRITICAL: Type Error occurred when creating object: Gigya\GigyaIM\Controller\Raas\Automatic
\Login\Interceptor, Too few arguments to function Gigya\GigyaIM\Controller\Raas\AbstractLogin::__construct(), 26 passed
in vendor/gigya/magento2-im/Controller/Raas/Automatic/Login.php on line 111 and exactly 28 expected
```